### PR TITLE
Реализовать модальное окно для начала рабочего дня

### DIFF
--- a/local/js/ajax.php
+++ b/local/js/ajax.php
@@ -1,0 +1,35 @@
+<?php
+define('NO_KEEP_STATISTIC', 'Y');
+define('NO_AGENT_STATISTIC', 'Y');
+define('NO_AGENT_CHECK', true);
+define('DisableEventsCheck', true);
+@define('PUBLIC_AJAX_MODE', true);
+
+require($_SERVER["DOCUMENT_ROOT"]."/bitrix/modules/main/include/prolog_before.php");
+
+use Bitrix\Main\Application;
+use Bitrix\Main\Loader;
+use Bitrix\Main\Engine\CurrentUser;
+
+Loader::includeModule('timeman');
+
+$context = Application::getInstance()->getContext();
+$request = $context->getRequest();
+$userId = CurrentUser::get()->getId();
+$tmUser = new CTimeManUser($userId);
+
+switch ($request['type']) {
+    case 'start':
+        $tmUser->OpenDay();
+        $tmUser->ReopenDay();
+        break;
+    case 'end':
+        $tmUser->CloseDay();
+        break;
+}
+
+echo \Bitrix\Main\Web\Json::encode([
+    'status' => $tmUser->State(),
+]);
+
+require($_SERVER["DOCUMENT_ROOT"]."/bitrix/modules/main/include/epilog_after.php");

--- a/local/js/script.js
+++ b/local/js/script.js
@@ -1,0 +1,76 @@
+
+function createButtonStartWorkingDay() {//Функция, делающая кнопку «Начать рабочий день»
+   const timemanStart = document.querySelector(".tm-popup-button-handler");
+   const timemanStartButton = timemanStart.querySelector("button");
+
+   if (timemanStartButton) {
+      const timemanStartNewButton = document.createElement("button");
+
+      timemanStartButton.style.display = "none";
+
+      timemanStartNewButton.classList.add("ui-btn", "ui-btn-primary", "ui-btn-icon-start");
+      timemanStartNewButton.textContent = 'Начать рабочий день';
+      timemanStartNewButton.addEventListener("click", clickStartWorkingDayPopup);
+      timemanStart.prepend(timemanStartNewButton);
+   }
+}
+
+function clickStartWorkingDayPopup() {//Функция, делающая кнопки «Начать рабочий день» и «Завершить рабочий день» в модальном окне.
+   const buttonStartJobDay = document.createElement('button');
+   buttonStartJobDay.className = 'ui-btn ui-btn-primary ui-btn-icon-start';
+   buttonStartJobDay.style.marginTop = '10px';
+   buttonStartJobDay.innerText = 'Начать рабочий день';
+   buttonStartJobDay.onclick = function() {
+      BX.ajax({
+         url: '/local/js/ajax.php',
+         data: {
+            type: 'start'
+         },
+         method: 'POST',
+         onsuccess: (data) => {
+            window.location.href = window.location.href;
+         }
+      });
+   };
+
+   const buttonEndJobDay = document.createElement('button');
+   buttonEndJobDay.className = 'ui-btn ui-btn-danger ui-btn-icon-stop';
+   buttonEndJobDay.style.marginLeft = '0';
+   buttonEndJobDay.style.marginTop = '10px';
+   buttonEndJobDay.innerText = 'Завершить рабочий день';
+   buttonEndJobDay.onclick = function() {
+      BX.ajax({ 
+         url: '/local/js/ajax.php',
+         data: {
+            type: 'end'
+         },
+         method: 'POST',
+         onsuccess: (data) => {
+            window.location.href = window.location.href;
+            
+         }
+      });
+   };
+
+   const messageBoxContent = document.createElement('div');
+   messageBoxContent.style.display = 'flex';
+   messageBoxContent.style.flexDirection = 'column';
+   messageBoxContent.appendChild(buttonStartJobDay);
+   messageBoxContent.appendChild(buttonEndJobDay);
+
+   const messageBox = BX.UI.Dialogs.MessageBox.create(
+       {
+          message: messageBoxContent,
+          title: "Начать рабочий день",
+          popupOptions: {
+             events: {
+                onPopupClose: function() {
+                }
+             }
+          }
+       }
+   );
+   messageBox.show();
+}
+
+BX.addCustomEvent("onTimeManWindowOpen", createButtonStartWorkingDay);

--- a/local/php_interface/js/scripts.php
+++ b/local/php_interface/js/scripts.php
@@ -1,0 +1,11 @@
+<?php
+
+use Bitrix\Main\Page\Asset;
+
+\CJSCore::RegisterExt("OtusWorkingDay", array(
+    "js" => "\local\js\script.js",
+    "css" => "",
+    "rel" => array(),
+));//Подключаем свои скрипты
+
+\CJSCore::Init(['OtusWorkingDay']); // Инициализация скрипта  рабочего дня


### PR DESCRIPTION
    Когда пользователь нажимает на кнопку «Начать рабочий день», расположенную в правом верхнем углу экрана, появляется модальное окно с произвольным текстом.
    В этом окне также отображается кнопка.
    Рабочий день начинается только после нажатия на эту кнопку.
    Если пользователь закрывает окно, начало рабочего дня отменяется.
